### PR TITLE
Preempt fix + example processor modification

### DIFF
--- a/src/skiros2_template_lib/template_primitives.py
+++ b/src/skiros2_template_lib/template_primitives.py
@@ -35,7 +35,7 @@ class my_primitive(PrimitiveBase):
 
     def onPreempt(self):
         """ Called when skill is requested to stop. """
-        return True
+        return self.fail("Stopped", -1)
 
     def onStart(self):
         """Called just before 1st execute"""

--- a/src/skiros2_template_lib/template_skills.py
+++ b/src/skiros2_template_lib/template_skills.py
@@ -1,4 +1,4 @@
-from skiros2_skill.core.skill import SkillDescription, SkillBase, ParallelFs, Sequential
+from skiros2_skill.core.skill import SkillDescription, SkillBase, ParallelFs, Serial
 from skiros2_common.core.params import ParamTypes
 from skiros2_common.core.world_element import Element
 
@@ -26,7 +26,7 @@ class my_skill(SkillBase):
         self.setDescription(MySkill(), self.__class__.__name__)
 
     def expand(self, skill):
-        skill.setProcessor(Sequential())
+        skill.setProcessor(Serial())
         skill(
             self.skill("MyPrimitive", "my_primitive")
         )


### PR DESCRIPTION
- Fixes the return value of `onPreempt` to an allowed return value
- Changes the example processor from "Sequential" to "Serial" as the former is marked to be deprecated